### PR TITLE
changed identity logoutPath

### DIFF
--- a/src/buyingcatalogue/values.yaml
+++ b/src/buyingcatalogue/values.yaml
@@ -180,7 +180,7 @@ isapi:
         name: "bc-buyingcatalogue"
         key: pb-url
       loginPath: /re-login
-      logoutPath: /logout-callback
+      logoutPath: /signout-callback-oidc
   allowInvalidCertificate: false
   dataProtection:
     applicationName: "ISAPI Development"


### PR DESCRIPTION
Given I spun up the local cluster
And I sign in with Alice
And I go for lunch
When I come back and attempt to navigate into order form
Then the site redirects me to https://host.docker.internal/logout-callback
And the page says Incorrect url /logout-callback

changed identity serviceDependencies pb logoutPath value in Values.yaml to /signout-callback-oidc

Given I spin up the cluster locally
And I sign in with Alice
When I navigate to https://host.docker.internal/signout-callback-oidc
Then I am automatically logged out